### PR TITLE
try to fix day/night theming issues

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -18,7 +18,7 @@ header:
     align: l
     show_logo: true
     show_language: false
-    show_day_night: false
+    show_day_night: true
     show_search: false
     highlight_active_link: true
 

--- a/content/NeurIPS_2021/details.md
+++ b/content/NeurIPS_2021/details.md
@@ -11,10 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/NeurIPS_2021/hero.md
+++ b/content/NeurIPS_2021/hero.md
@@ -24,8 +24,6 @@ weight = 1  # Order that this section will appear.
   # image_position = "center"  # Options include `left`, `center` (default), or `right`.
   image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/NeurIPS_2021/organizers.md
+++ b/content/NeurIPS_2021/organizers.md
@@ -11,11 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/NeurIPS_2021/sponsors.md
+++ b/content/NeurIPS_2021/sponsors.md
@@ -11,11 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/NeurIPS_2021/summary.md
+++ b/content/NeurIPS_2021/summary.md
@@ -11,10 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/NeurIPS_2021/winners.md
+++ b/content/NeurIPS_2021/winners.md
@@ -11,10 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/NeurIPS_2022/hero.md
+++ b/content/NeurIPS_2022/hero.md
@@ -22,9 +22,6 @@ weight = 1  # Order that this section will appear.
   # image_position = "center"  # Options include `left`, `center` (default), or `right`.
   image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["100px", "0", "20px", "0"]

--- a/content/NeurIPS_2022/organizers.md
+++ b/content/NeurIPS_2022/organizers.md
@@ -11,11 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/NeurIPS_2022/sponsors.md
+++ b/content/NeurIPS_2022/sponsors.md
@@ -11,10 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/NeurIPS_2022/summary.md
+++ b/content/NeurIPS_2022/summary.md
@@ -11,11 +11,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "2"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/contributing/contributing.md
+++ b/content/contributing/contributing.md
@@ -15,11 +15,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "1"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/contributing/developer_guide.md
+++ b/content/contributing/developer_guide.md
@@ -15,10 +15,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "1"
 
-[design.background]
-    # Text color (true=light or false=dark).
-  text_color_light = false
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/contributing/hero.md
+++ b/content/contributing/hero.md
@@ -24,9 +24,6 @@ subtitle = "[Join Us on Slack!](https://join-cziscience-slack.herokuapp.com/) <b
   # image_position = "center"  # Options include `left`, `center` (default), or `right`.
   image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["100px", "0", "20px", "0"]

--- a/content/home/about.md
+++ b/content/home/about.md
@@ -15,24 +15,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "1"
 
-[design.background]
-  # Apply a background color, gradient, or image.
-  #   Uncomment (by removing `#`) an option to apply it.
-  #   Choose a light or dark text color by setting `text_color_light`.
-  #   Any HTML color name or Hex value is valid.
-
-  # Background color.
-  # color = "navy"
-
-  # Background gradient.
-  # gradient_start = "DeepSkyBlue"
-  # gradient_end = "SkyBlue"
-
-  # Background image.
-
-
-  # Text color (true=light or false=dark).
-  text_color_light = false
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/home/hero.md
+++ b/content/home/hero.md
@@ -23,9 +23,6 @@ text_img = "heros/home_hero_text.png"
    image_darken = 0  # Darken the image? Range 0-1 where 0 is transparent and 1 is opaque.
    image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["0px", "0", "0", "0"]

--- a/content/home/results.md
+++ b/content/home/results.md
@@ -15,10 +15,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "1"
 
-
-  # Text color (true=light or false=dark).
-  text_color_light = false
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/jamboree/hero.md
+++ b/content/jamboree/hero.md
@@ -24,8 +24,6 @@ subtitle = "We're excited for you to join us for our hackathon March 29-31, 2021
   # image_position = "center"  # Options include `left`, `center` (default), or `right`.
   image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/content/jamboree/information.md
+++ b/content/jamboree/information.md
@@ -15,11 +15,6 @@ subtitle = ""
   # Choose how many columns the section has. Valid values: 1 or 2.
   columns = "1"
 
-[design.background]
-  # Text color (true=light or false=dark).
-  text_color_light = false
-  color = "white"
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/results/hero.md
+++ b/content/results/hero.md
@@ -35,9 +35,6 @@ subtitle = "*This page is under construction*"
   # image_position = "center"  # Options include `left`, `center` (default), or `right`.
   image_parallax = false  # Use a fun parallax-like fixed background effect? true/false
 
-  # Text color (true=light or false=dark).
-  text_color_light = true
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["100px", "0", "20px", "0"]

--- a/content/results/label_projection.md
+++ b/content/results/label_projection.md
@@ -16,9 +16,6 @@ subtitle = "*Using cell labels from a reference dataset to annotate an unseen da
   columns = "1"
 
 
-  # Text color (true=light or false=dark).
-  text_color_light = false
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/content/results/multimodal_data_integration.md
+++ b/content/results/multimodal_data_integration.md
@@ -16,9 +16,6 @@ subtitle = "*Realigning multimodal measurements of the same cell*"
   columns = "1"
 
 
-  # Text color (true=light or false=dark).
-  text_color_light = false
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]

--- a/data/themes/minimal.toml
+++ b/data/themes/minimal.toml
@@ -20,23 +20,3 @@ name = "minimal"
   # Home sections
   home_section_odd = "rgb(255, 255, 255)"
   home_section_even = "rgb(255, 255, 255)"
-
-# Is theme light or dark?
-[dark]
-
-  # Primary
-  primary = "#ff414b"
-
-  # Links
-  link = "#ff414b"
-  link_hover = "#bf4148"
-  
-  # Menu
-  menu_primary = "#fff"
-  menu_text = "#34495e"
-  menu_text_active = "#ff414b"
-  menu_title = "#2b2b2b"
-  
-  # Home sections
-  home_section_odd = "rgb(255, 255, 255)"
-  home_section_even = "rgb(255, 255, 255)"

--- a/layouts/shortcodes/sponsors.html
+++ b/layouts/shortcodes/sponsors.html
@@ -3,7 +3,7 @@
   <div class="col-md-1"></div>
   <div class="col-md-5">
     <div class="card" style="width: 300px; height:300px;">
-      <img class="card-img-top" src="/media/sponsor/logotypemarkcolor.svg" alt="Card image cap" style="width:200px;  margin: 40px 50px 20px;">
+      <img class="card-img-top" src="/media/sponsor/logotypemarkcolor.svg" alt="Card image cap" style="width:200px;  margin: 40px 50px 20px; background-color:white;">
       <div class="card-body" style="padding-top: 0px;">
         <p class="card-text">Cellarity is redefining drug discovery by targeting cell behaviors as opposed to individual proteins.<br><a class="stretched-link" href="https://cellarity.com/careers?utm_source=neurips&utm_medium=push-notification&utm_campaign=neurips&utm_content=neurips-competition">Learn more.</a></p>
       </div>
@@ -13,7 +13,7 @@
 
   <div class="col-md-5">
     <div class="card" style="width: 300px; height:300px;">
-      <img class="card-img-top" src="/media/sponsor/CZI_Logotype.svg" style="width:150px; margin: 20px 60px 10px; ">
+      <img class="card-img-top" src="/media/sponsor/CZI_Logotype.svg" style="width:150px; margin: 20px 60px 10px; background-color:white;">
       <div class="card-body" style="padding-top: 0px;">
         <p class="card-text" style="line-height: 1.3rem;">CZI leverages technology and collaboration to accelerate progress in science, education and community work.<br> <a class="stretched-link" href="https://czi.org">Learn more.</a></p>
       </div>
@@ -23,7 +23,7 @@
 
 <div class="row">
   <div class="col-md-4">
-    <div class="card" style="width: 250px; height:120px;">
+    <div class="card" style="width: 250px; height:120px; background-color:white;">
       <img class="card-img-top" src="/media/sponsor/biohub_logo.svg" alt="Card image cap" style="width:170px;  margin: 25px 40px;">
       <div class="card-body" style="padding-top: 0px;">
         <a class="stretched-link" href="https://www.czbiohub.org/"></a>
@@ -32,7 +32,7 @@
   </div>
 
   <div class="col-md-4">
-    <div class="card" style="width: 250px; height:120px;">
+    <div class="card" style="width: 250px; height:120px; background-color:white;">
       <img class="card-img-top" src="/media/sponsor/yale-logo-sprite.svg" alt="Card image cap" style="width:130px;  margin: 22px 60px;">
       <div class="card-body" style="padding-top: 0px;">
         <a class="stretched-link" href="https://www.yale.edu/"></a>
@@ -42,7 +42,7 @@
 
 
   <div class="col-md-4">
-    <div class="card" style="width: 250px; height:120px;">
+    <div class="card" style="width: 250px; height:120px; background-color:white;">
       <img class="card-img-top" src="/media/sponsor/helmholtz_logotype.svg" alt="Card image cap" style="width:225px;  margin: 40px 12.5px">
       <div class="card-body" style="padding-top: 0px;">
         <a class="stretched-link" href="https://www.helmholtz-muenchen.de/icb/index.html"></a>

--- a/results_frontmatter/label_projection.md
+++ b/results_frontmatter/label_projection.md
@@ -16,8 +16,6 @@ subtitle = "Using cell labels from a reference dataset to annotate an unseen dat
   columns = "1"
 
 
-  # Text color (true=light or false=dark).
-  text_color_light = false
 
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.

--- a/results_frontmatter/multimodal_data_integration.md
+++ b/results_frontmatter/multimodal_data_integration.md
@@ -16,9 +16,6 @@ subtitle = "Realigning multimodal measurements of the same cell using various te
   columns = "1"
 
 
-  # Text color (true=light or false=dark).
-  text_color_light = false
-
 [design.spacing]
   # Customize the section spacing. Order is top, right, bottom, left.
   padding = ["20px", "0", "20px", "0"]


### PR DESCRIPTION
In the past, there were issues on the website where the website was not legible for users with a dark theme. It looked a little something like this:

<details>
  <summary>Screenshot of old website</summary>

![Screenshot from 2022-10-14 15-47-05](https://user-images.githubusercontent.com/553642/195862677-4f567b4b-9d82-4d84-9b51-e4b530340c8a.png)

</details>

Commit e1a18c02e7eaeb710ad257c5bf453f608ed1ffb0 solved this issue by ensuring that dark theme colours are set to the same values as the light theme. However, now the opposite problem appears in the "Team" page and others:


<details>
  <summary>Screenshots of current website</summary>

[Team](https://openproblems.bio/team/): 

![Screenshot from 2022-10-14 15-49-14](https://user-images.githubusercontent.com/553642/195863202-57728ac4-d4b4-42ec-a959-de07315f7366.png)

[Sponsors](https://openproblems.bio/neurips_2021/#sponsors):

![Screenshot from 2022-10-14 15-53-41](https://user-images.githubusercontent.com/553642/195864127-8d9b9a36-272c-4024-ae2f-e736f7c3dc94.png)

[NeurIPS 2021 Winners](https://openproblems.bio/neurips_2021/#winners):

![Screenshot from 2022-10-14 15-55-13](https://user-images.githubusercontent.com/553642/195864454-dbb27709-a6e6-44e3-8b09-5a6123752bca.png)

</details>

I dug a little bit into Wowchemy and couldn't find a way to permanently disable the 'night' theme and only offer the 'day' theme. 
I also don't think the Wowchemy developers intended on the dark theme to be disabled.

However, I found that most of the issues were caused by fixing the `text_color_light` to `true` or `false` for many of the pages where it perhaps was not needed. I propose only setting the `text_color_light` to true or to false when there is an explicit background image or colour defined, and otherwise removing it.

I think this PR solves all of the aforementioned issues.


<details>
  <summary>Screenshots of proposed changes</summary>

Main page:

![Screenshot from 2022-10-14 15-57-13](https://user-images.githubusercontent.com/553642/195864856-1e660d90-d5ec-437c-a06a-fbf618ec8b00.png)

Team:

![Screenshot from 2022-10-14 15-57-37](https://user-images.githubusercontent.com/553642/195864924-479f72ca-1a9d-4474-a69e-d47685616e01.png)

NeurIPS 2021 winners and sponsors:

![Screenshot from 2022-10-14 15-58-29](https://user-images.githubusercontent.com/553642/195865145-a0cf33f3-e1ce-4a63-b781-a4159912151e.png)


</details>

There are some minor issues with figures (in the NeurIPS2021 documentation) and logos (e.g. Cellarity and CZI). I'll try to have a look at these in a next PR. At any rate, by re-enabling the Day/Night button allows users to switch between the two. I'll look at a solution for logos in a next PR.