### PR TITLE
Make people 'cards' a little bit wider

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -131,3 +131,13 @@ a {
 span {
   font-family: 'hk_groteskmedium', Fallback, sans-serif;
 }
+
+// override the default width for a people widget
+// based on: https://github.com/wowchemy/wowchemy-hugo-themes/blob/c51be55f93177c75578521f7a513eec87a7cb818/modules/wowchemy/assets/scss/wowchemy/widgets/_people.scss#L29
+// at the moment, setting the width to 25% works better for our site
+// since a lot of the groups have 6 people in it.
+@media (min-width: 992px) {
+  .people-widget .col-sm-auto {
+    width: 25%;
+  }
+}


### PR DESCRIPTION
Currently, all of our author groups have 6 people in them. Since the people widget renders an author with 20% width, this results in an awkward 5-1 split:

![Screenshot from 2022-10-25 06-34-51](https://user-images.githubusercontent.com/553642/197683569-55116584-ffdc-4896-9040-1496c34cd408.png)

By setting the default width to 25%, the split is a lot better:

![Screenshot from 2022-10-25 06-36-07](https://user-images.githubusercontent.com/553642/197683643-14518917-7c77-4314-8758-57811d271178.png)

@dburkhardt Can you review and merge?
