### PR TITLE
fix external link filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ of a stub task.
 ## BUG FIXES
 
 * Fix internal links being treated as external links in PR previews (#179).
+* FIx `link-external-filter` te recognise internal filters on published website (#202)
 
 # openproblems.bio v2.0.0
 

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -60,7 +60,7 @@ format:
     toc: true
     link-external-newwindow: true
     # link-external-icon: true
-    link-external-filter: '^(?:http:|https:)\/\/(www\.openproblems\.bio|[^.]*--openproblems\.netlify\.app)'
+    link-external-filter: '^(?:http:|https:)\/\/(openproblems\.bio|[^.]*--openproblems\.netlify\.app)'
     smooth-scroll: true
 
 execute:


### PR DESCRIPTION
## Describe your changes
Remove "www\." from publish link in `link-external-filter`. The published URL does not start with "www". This introduced a bug that on the published website internal links were recognised as an external URL.

## Issue ticket number and link
Closes #202 

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [x] Bug fixes

- [x] Proposed changes are described in the CHANGELOG.md

- [x] CI Preview succeeds and looks good!