### PR TITLE
Add dual license

### DIFF
--- a/LICENSE-CC-BY
+++ b/LICENSE-CC-BY
@@ -1,6 +1,6 @@
 Creative Commons CC-BY License
 
-Copyright (c) 2023 Open Problems
+Copyright (c) 2020 Open Problems
 
 Attribution 4.0 International
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Open Problems
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## OpenProblems.bio
+# OpenProblems.bio
 
 This repository is used to build [openproblems.bio](https://openproblems.bio).
 
@@ -19,3 +19,9 @@ Run `quarto preview` to render a preview version of the site.
 
 Run `quarto render` to render the site.
 
+## License
+
+This repository contains a Quarto website with different types of content:
+
+- Markdown content and JSON data files are licensed under the Creative Commons Attribution 4.0 International License (CC-BY). See [`LICENSE-CC-BY`](./LICENSE-CC-BY) for details.
+- All other source files (e.g. R, Python, CSS, SCSS, and EJS) are licensed under the MIT License. See [`LICENSE-MIT`](./LICENSE-MIT) for details.


### PR DESCRIPTION
Proposal for a dual license (#216) to make sure our Python and R code is still licensed with MIT and not CC-BY