### PR TITLE
Patch: Update image version to :1

### DIFF
--- a/documentation/create_task/dataset_processor.qmd
+++ b/documentation/create_task/dataset_processor.qmd
@@ -56,7 +56,7 @@ resources: #<4>
 
 engines: 
   - type: docker #<7>
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners: 
   - type: executable
@@ -93,7 +93,7 @@ resources: #<4>
 
 engines: 
   - type: docker #<7>
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners: 
   - type: executable


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.